### PR TITLE
Implement error propagation

### DIFF
--- a/internal/service-unit/infrastructure/adapters/primary/consumer/kafka/consumer.go
+++ b/internal/service-unit/infrastructure/adapters/primary/consumer/kafka/consumer.go
@@ -65,6 +65,7 @@ func (kca KafkaConsumerAdapter) Serve(ctx context.Context, wg *sync.WaitGroup) e
 			for _, err := range errs {
 				kca.kafkaConsumer.handler.LogTaskError(ctx, err)
 			}
+			// TODO: Consider error handling for failed topic. Maybe requeueing?
 		}
 
 		kca.log(ctx, startTime)

--- a/internal/service-unit/infrastructure/adapters/primary/server/rest/server.go
+++ b/internal/service-unit/infrastructure/adapters/primary/server/rest/server.go
@@ -77,7 +77,7 @@ func (rsa *RestServerAdapter) Register(handler *ports.PrimaryHandler) error {
 				}
 
 				restResponse := contract.RestResponseBody{}
-				return c.Status(fiber.StatusOK).JSON(restResponse)
+				return c.Status(fiber.StatusInternalServerError).JSON(restResponse)
 			}
 
 			// write response
@@ -106,7 +106,7 @@ func (rsa *RestServerAdapter) Register(handler *ports.PrimaryHandler) error {
 					handler.LogTaskError(c.UserContext(), err)
 				}
 				restResponse := contract.RestResponseBody{}
-				return c.Status(fiber.StatusOK).JSON(restResponse)
+				return c.Status(fiber.StatusInternalServerError).JSON(restResponse)
 			}
 
 			// write response


### PR DESCRIPTION
## What
Implemented error propagation for REST HTTP primary adapter. It now returns 500 internal server error when one of the secondary adapter call fails.

gRPC already returned error when one of the secondary adapter call failed.

also left todo comment on kafka consumer adapter as it should be revisited when considering requeueu mechanisms for failed requests. The error handling for asynchronous adapter must be revisited.

This should be revisited when implementing partial failures.