### PR TITLE
Implement hexctl command to apply adaptive timeout recursively

### DIFF
--- a/cmd/hexctl/commands/adapto.go
+++ b/cmd/hexctl/commands/adapto.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"os"
+	"strings"
+
+	"github.com/hanapedia/hexagon/internal/hexctl/adapto"
+	"github.com/hanapedia/hexagon/pkg/operator/logger"
+	"github.com/spf13/cobra"
+)
+
+// adaptoCmd represents the generate command
+var adaptoCmd = &cobra.Command{
+	Use:   "adapto",
+	Short: "adds adapto configuration to given service unit configurations.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if strings.TrimSpace(inputPath) == "" {
+			logger.Logger.Fatalln("Missing -f flag or empty file path")
+		}
+
+		fileInfo, err := os.Stat(inputPath)
+		if err != nil {
+			logger.Logger.Fatalln(err)
+		}
+		if !fileInfo.IsDir() {
+			logger.Logger.Fatalln("The input path is not a directory.")
+		}
+
+		adapto.GenerateFromDirectory(inputPath, outputPath)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(adaptoCmd)
+	adaptoCmd.PersistentFlags().StringVarP(&inputPath, "file", "f", "", "YAML file or directory to validate")
+	adaptoCmd.PersistentFlags().StringVarP(&outputPath, "out", "o", "", "output directory for generated files")
+}

--- a/internal/hexctl/adapto/generate.go
+++ b/internal/hexctl/adapto/generate.go
@@ -1,0 +1,118 @@
+package adapto
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/hanapedia/hexagon/internal/hexctl/loader"
+	"github.com/hanapedia/hexagon/internal/hexctl/manifest/core"
+	model "github.com/hanapedia/hexagon/pkg/api/v1"
+	"github.com/hanapedia/hexagon/pkg/hexctl/graph"
+	"github.com/hanapedia/hexagon/pkg/operator/constants"
+	"github.com/hanapedia/hexagon/pkg/operator/logger"
+	"github.com/hanapedia/hexagon/pkg/operator/yaml"
+)
+
+type AdaptoGenerator struct {
+	// ServiceUnitConfigs is a map containing ServiceUnitConfigs keyed by the input path
+	ServiceUnitConfigs map[string]*model.ServiceUnitConfig
+	ClusterConfig      *model.ClusterConfig
+	Graph              *graph.Graph
+}
+
+func GenerateFromDirectory(input, output string) {
+	// Attempt to parse the cluster config file first
+	clusterConfig := loader.GetClusterConfig(filepath.Join(input, constants.CLUSTER_CONFIG_FILE_NAME))
+
+	paths, err := loader.GetYAMLFiles(input)
+	if err != nil {
+		logger.Logger.Fatalf("Error reading from directory %s. %s", input, err)
+	}
+
+	serviceUnitConfigs := map[string]*model.ServiceUnitConfig{}
+	for _, path := range paths {
+		outputPath := loader.ReplaceInputDirectory(path, input, output)
+		serviceUnitConfigs[outputPath] = loader.GetServiceUnitConfig(path)
+	}
+	ag := AdaptoGenerator{
+		ClusterConfig:      clusterConfig,
+		ServiceUnitConfigs: serviceUnitConfigs,
+	}
+	ag.GenerateGraph()
+	ag.PatchServiceUnitConfigs()
+	ag.RewriteYAML()
+}
+
+// generate generates GraphML compatible Graph
+func (ag *AdaptoGenerator) GenerateGraph() {
+	graph := graph.Graph{}
+
+	// Loop through ServiceUnitConfigs
+	for _, suc := range ag.ServiceUnitConfigs {
+		serviceName := suc.Name
+		for _, primary := range suc.AdapterConfigs {
+			graph.AddNode(primary.GetId(serviceName), map[string]interface{}{"config": primary})
+			for _, taskSpec := range primary.TaskSpecs {
+				if taskSpec.AdapterConfig.Type() == model.Invocation {
+					graph.AddEdge(primary.GetId(serviceName), taskSpec.AdapterConfig.GetId())
+				}
+			}
+		}
+	}
+	ag.Graph = &graph
+}
+
+// generate generates GraphML compatible Graph
+func (ag *AdaptoGenerator) PatchServiceUnitConfigs() {
+	// apply depth first search
+	// callsMap contains the recursive call counters for each primary adapter
+	// should set the adaptive timeout based on (counter + 1) * base timeout
+	callsMap := ag.Graph.CalculateRecursiveCalls()
+	baseTimeout, err := ag.ClusterConfig.GetBaseTimeout()
+	if err != nil {
+		baseTimeout = model.DEFAULT_ADAPTIVE_TIMEOUT_MAX
+	}
+	for _, suc := range ag.ServiceUnitConfigs {
+		for _, primary := range suc.AdapterConfigs {
+			for _, taskSpec := range primary.TaskSpecs {
+				if taskSpec.AdapterConfig.Type() != model.Invocation {
+					continue
+				}
+				calls, ok := callsMap[taskSpec.AdapterConfig.GetId()]
+				if !ok {
+					logger.Logger.Errorf("No matching adapter found.")
+					continue
+				}
+				taskSpec.Resiliency.AdaptiveCallTimeout = model.AdaptiveTimeoutSpec{
+					RTO:                     true,
+					FailureRateSLO:          ag.ClusterConfig.AdaptiveTimeout.FailureRateSLO,
+					LatencySLO:              (baseTimeout * time.Duration(calls+1)).String(),
+					Interval:                ag.ClusterConfig.AdaptiveTimeout.Interval,
+					KMargin:                 ag.ClusterConfig.AdaptiveTimeout.KMargin,
+					OverloadDrainIntervals:  ag.ClusterConfig.AdaptiveTimeout.OverloadDrainIntervals,
+					OverloadDetectionTiming: ag.ClusterConfig.AdaptiveTimeout.OverloadDetectionTiming,
+				}
+			}
+		}
+	}
+}
+
+// RewriteYAML rewrites service unit configs with patched fields
+func (ag *AdaptoGenerator) RewriteYAML() {
+	for path, suc := range ag.ServiceUnitConfigs {
+		// Open the manifestFile in append mode and with write-only permissions
+		file, err := core.CreateFile(path)
+		if err != nil {
+			logger.Logger.WithField("path", path).Errorf("Error creating output file.")
+			continue
+		}
+		defer file.Close()
+
+		serviceUnitConfigYaml := yaml.GenerateManifest(suc)
+		_, err = file.WriteString(core.FormatManifest(serviceUnitConfigYaml))
+		if err != nil {
+			logger.Logger.WithField("path", path).Errorf("Error writing to output file.")
+			continue
+		}
+	}
+}

--- a/internal/hexctl/graph/generate.go
+++ b/internal/hexctl/graph/generate.go
@@ -104,7 +104,7 @@ func addEdge(graph *graphml.Graph, source, destination, edgeLabel string) error 
 }
 
 // parseSteps parses tasks and update graph.
-func parseSteps(graph *graphml.Graph, serviceName string, tasks []model.TaskSpec) {
+func parseSteps(graph *graphml.Graph, serviceName string, tasks []*model.TaskSpec) {
 	for _, task := range tasks {
 		var destination, edgeLabel string
 		if task.AdapterConfig.ProducerConfig != nil {

--- a/internal/hexctl/loader/loader.go
+++ b/internal/hexctl/loader/loader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"strings"
 
 	"github.com/hanapedia/hexagon/internal/config/application/ports"
 	"github.com/hanapedia/hexagon/internal/config/infrastructure/yaml"
@@ -65,4 +66,22 @@ func GetYAMLFiles(dir string) ([]string, error) {
 	}
 
 	return yamlFiles, nil
+}
+
+// ReplaceInputDirectory replaces the current parent directory with new parent directory
+// while preserving the other children directories
+func ReplaceInputDirectory(path string, oldParent, newParent string) string {
+	oldParent = filepath.Clean(oldParent)
+	newParent = filepath.Clean(newParent)
+	// Check if the path starts with the old parent directory
+	if strings.HasPrefix(path, oldParent) {
+		// Replace the old parent directory with the new parent directory
+		relativePath, err := filepath.Rel(oldParent, path)
+		if err != nil {
+			fmt.Printf("Error getting relative path for %s: %v\n", path, err)
+			return path
+		}
+		return filepath.Join(newParent, relativePath)
+	}
+	return path
 }

--- a/internal/service-unit/application/core/initialization/mapadapters.go
+++ b/internal/service-unit/application/core/initialization/mapadapters.go
@@ -14,8 +14,8 @@ import (
 // mapSecondaryToPrimary map secondary adapter to primary adapter
 func (su *ServiceUnit) mapSecondaryToPrimary() {
 	for _, primaryConfig := range su.Config.AdapterConfigs {
-		taskSet := su.newTaskSet(&primaryConfig)
-		handler, err := su.newPrimaryAdapterHandler(&primaryConfig, taskSet)
+		taskSet := su.newTaskSet(primaryConfig)
+		handler, err := su.newPrimaryAdapterHandler(primaryConfig, taskSet)
 		if err != nil {
 			l.Logger.Fatalf("Error creating handler: %v", err)
 		}

--- a/internal/service-unit/application/core/runtime/taskhandler_test.go
+++ b/internal/service-unit/application/core/runtime/taskhandler_test.go
@@ -29,7 +29,7 @@ func TestRegularCalls(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					Retry:         model.RetrySpec{Disabled: true},
 					CircutBreaker: model.CircuitBreakerSpec{Disabled: true},
 				}},
@@ -37,7 +37,7 @@ func TestRegularCalls(t *testing.T) {
 			),
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					Retry:         model.RetrySpec{Disabled: true},
 					CircutBreaker: model.CircuitBreakerSpec{Disabled: true},
 				}},
@@ -67,7 +67,7 @@ func TestConcurrentCalls(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					IsCritical:    true,
 					Retry:         model.RetrySpec{Disabled: true},
 					CircutBreaker: model.CircuitBreakerSpec{Disabled: true},
@@ -76,7 +76,7 @@ func TestConcurrentCalls(t *testing.T) {
 			),
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					IsCritical:    true,
 					Retry:         model.RetrySpec{Disabled: true},
 					CircutBreaker: model.CircuitBreakerSpec{Disabled: true},
@@ -107,7 +107,7 @@ func TestRetrySuccess(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{
+				&model.TaskSpec{
 					Resiliency: model.ResiliencySpec{
 						Retry: model.RetrySpec{
 							BackoffPolicy:  model.NO_BACKOFF,
@@ -142,7 +142,7 @@ func TestRetryFail(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{
+				&model.TaskSpec{
 					Resiliency: model.ResiliencySpec{
 						Retry: model.RetrySpec{
 							BackoffPolicy:  model.NO_BACKOFF,
@@ -177,7 +177,7 @@ func TestNonCriticalFailure(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					Retry:         model.RetrySpec{Disabled: true},
 					CircutBreaker: model.CircuitBreakerSpec{Disabled: true},
 				}},
@@ -185,7 +185,7 @@ func TestNonCriticalFailure(t *testing.T) {
 			),
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					Retry:         model.RetrySpec{Disabled: true},
 					CircutBreaker: model.CircuitBreakerSpec{Disabled: true},
 				}},
@@ -215,7 +215,7 @@ func TestCriticalFailure(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					IsCritical:    true,
 					Retry:         model.RetrySpec{Disabled: true},
 					CircutBreaker: model.CircuitBreakerSpec{Disabled: true},
@@ -224,7 +224,7 @@ func TestCriticalFailure(t *testing.T) {
 			),
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					Retry:         model.RetrySpec{Disabled: true},
 					CircutBreaker: model.CircuitBreakerSpec{Disabled: true},
 				}},
@@ -254,7 +254,7 @@ func TestCallTimeoutFailure(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					CallTimeout:   "5ms",
 					Retry:         model.RetrySpec{Disabled: true},
 					CircutBreaker: model.CircuitBreakerSpec{Disabled: true},
@@ -284,7 +284,7 @@ func TestTaskTimeoutFailure(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					TaskTimeout: "1s",
 					Retry: model.RetrySpec{
 						BackoffPolicy:  model.NO_BACKOFF,
@@ -318,7 +318,7 @@ func TestCallAndTaskTimeoutFailure(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					CallTimeout: "1ms",
 					TaskTimeout: "1s",
 					Retry: model.RetrySpec{
@@ -359,7 +359,7 @@ func TestCircuitBreakerWithoutThresh(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					CircutBreaker: model.CircuitBreakerSpec{
 						MaxRequests:      1,
 						Interval:         "10s",
@@ -412,7 +412,7 @@ func TestCircuitBreakerRatioThresh(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					CircutBreaker: model.CircuitBreakerSpec{
 						MaxRequests:      1,
 						Interval:         "10s",
@@ -466,7 +466,7 @@ func TestCircuitBreakerConsecutiveFailsThresh(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					CircutBreaker: model.CircuitBreakerSpec{
 						MaxRequests:      1,
 						Interval:         "10s",
@@ -520,7 +520,7 @@ func TestCircuitBreakerHalfOpen(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					CircutBreaker: model.CircuitBreakerSpec{
 						MaxRequests:      1,
 						Interval:         "10s",
@@ -586,7 +586,7 @@ func TestRetryThenCircuitBreak(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					CircutBreaker: model.CircuitBreakerSpec{
 						MaxRequests:      1,
 						Interval:         "10s",
@@ -643,7 +643,7 @@ func TestCircuitBreakThenRetry(t *testing.T) {
 		TaskSet: []domain.TaskHandler{
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: name}},
-				model.TaskSpec{Resiliency: model.ResiliencySpec{
+				&model.TaskSpec{Resiliency: model.ResiliencySpec{
 					CircutBreaker: model.CircuitBreakerSpec{
 						MaxRequests:      1,
 						Interval:         "10s",

--- a/internal/service-unit/infrastructure/resiliency/taskhandler.go
+++ b/internal/service-unit/infrastructure/resiliency/taskhandler.go
@@ -9,7 +9,7 @@ import (
 	model "github.com/hanapedia/hexagon/pkg/api/v1"
 )
 
-func NewTaskHandler(telCtx domain.TelemetryContext, spec model.TaskSpec, adapter secondary.SecodaryPort) domain.TaskHandler {
+func NewTaskHandler(telCtx domain.TelemetryContext, spec *model.TaskSpec, adapter secondary.SecodaryPort) domain.TaskHandler {
 	var handler CallWithContextAlias = WithUnWrapTaskContext(adapter.Call)
 	var circuitBreaker CircuitBreaker = nil
 

--- a/pkg/api/v1/clusterconfig.go
+++ b/pkg/api/v1/clusterconfig.go
@@ -1,6 +1,10 @@
 package v1
 
-import "github.com/hanapedia/hexagon/pkg/api/defaults"
+import (
+	"time"
+
+	"github.com/hanapedia/hexagon/pkg/api/defaults"
+)
 
 type ClusterConfig struct {
 	ConfigTemplate
@@ -17,6 +21,8 @@ type ClusterConfig struct {
 	Mongo             MongoClusterConfig         `json:"mongo,omitempty"`
 	Redis             RedisClusterConfig         `json:"redis,omitempty"`
 	Otel              OtelCollectorClusterConfig `json:"otel,omitempty"`
+	AdaptiveTimeout   AdaptiveTimeoutSpec        `json:"adaptiveTimeout,omitempty"`
+	BaseTimeout       string                     `json:"baseTimeout,omitempty"`
 }
 
 type TracingClusterConfig struct {
@@ -83,4 +89,13 @@ func NewClusterConfig() ClusterConfig {
 			Namespace: defaults.OTEL_COLLECTOR_NAMESPACE,
 		},
 	}
+}
+
+// Parses BaseTimeout with time.ParseDuration
+func (cc *ClusterConfig) GetBaseTimeout() (time.Duration, error) {
+	duration, err := time.ParseDuration(cc.BaseTimeout)
+	if err != nil {
+		return duration, err
+	}
+	return duration, nil
 }

--- a/pkg/api/v1/secondaryadapter.go
+++ b/pkg/api/v1/secondaryadapter.go
@@ -6,6 +6,15 @@ import (
 	"github.com/hanapedia/hexagon/pkg/operator/constants"
 )
 
+type SecondaryAdapterType int64
+
+const (
+	Invocation SecondaryAdapterType = iota
+	RepositoryClient
+	Producer
+	Stressor
+)
+
 // secondary Adapter definition for a task.
 // one of the adapter type must be provided
 type SecondaryAdapterConfig struct {
@@ -51,16 +60,14 @@ type StressorConfig struct {
 // Get secondary adapter id
 func (sac *SecondaryAdapterConfig) GetId() string {
 	var id string
-	if sac.InvocationConfig != nil {
+	switch sac.Type() {
+	case Invocation:
 		id = sac.InvocationConfig.GetId()
-	}
-	if sac.ProducerConfig != nil {
+	case Producer:
 		id = sac.ProducerConfig.GetId()
-	}
-	if sac.RepositoryConfig != nil {
+	case RepositoryClient:
 		id = sac.RepositoryConfig.GetId()
-	}
-	if sac.StressorConfig != nil {
+	case Stressor:
 		id = sac.StressorConfig.GetId()
 	}
 	return id
@@ -70,19 +77,36 @@ func (sac *SecondaryAdapterConfig) GetId() string {
 // Get secondary adapter id
 func (sac SecondaryAdapterConfig) GetGroupByKey() string {
 	var key string
-	if sac.InvocationConfig != nil {
+	switch sac.Type() {
+	case Invocation:
 		key = sac.InvocationConfig.GetGroupByKey()
-	}
-	if sac.ProducerConfig != nil {
+	case Producer:
 		key = sac.ProducerConfig.GetGroupByKey()
-	}
-	if sac.RepositoryConfig != nil {
+	case RepositoryClient:
 		key = sac.RepositoryConfig.GetGroupByKey()
-	}
-	if sac.StressorConfig != nil {
+	case Stressor:
 		key = sac.StressorConfig.GetGroupByKey()
 	}
 	return key
+}
+
+// Get secondary adapter type
+func (sac *SecondaryAdapterConfig) Type() SecondaryAdapterType {
+	if sac.InvocationConfig != nil {
+		return Invocation
+	}
+	if sac.ProducerConfig != nil {
+		return Producer
+	}
+	if sac.RepositoryConfig != nil {
+		return RepositoryClient
+	}
+	if sac.StressorConfig != nil {
+		return Stressor
+	}
+
+	// Should not happen
+	return 0
 }
 
 // Get server secondary adapter id

--- a/pkg/api/v1/serviceunitconfig.go
+++ b/pkg/api/v1/serviceunitconfig.go
@@ -5,6 +5,6 @@ type ServiceUnitConfig struct {
 	ConfigTemplate
 	Name           string               `json:"name,omitempty" validate:"required"`
 	Version        string               `json:"version,omitempty" validate:"required"`
-	AdapterConfigs []PrimaryAdapterSpec `json:"adapters,omitempty" validate:"required"`
+	AdapterConfigs []*PrimaryAdapterSpec `json:"adapters,omitempty" validate:"required"`
 	DeploymentSpec DeploymentSpec       `json:"deployment,omitempty"`
 }

--- a/pkg/hexctl/graph/graph.go
+++ b/pkg/hexctl/graph/graph.go
@@ -1,0 +1,58 @@
+// Graph representation of service units
+// Uses more efficient data structure, Adjacency List, compared to graphml package that uses list of nodes and edges.
+package graph
+
+type Graph struct {
+	Nodes     map[string]*Node    // Node ID -> Node
+	Adjacency map[string][]string // Node ID -> List of neighbors
+}
+
+type Node struct {
+	ID   string
+	Data map[string]interface{}
+}
+
+// Adds a node to the graph
+func (g *Graph) AddNode(nodeID string, data map[string]interface{}) {
+	if g.Nodes == nil {
+		g.Nodes = make(map[string]*Node)
+	}
+	if g.Adjacency == nil {
+		g.Adjacency = make(map[string][]string)
+	}
+	g.Nodes[nodeID] = &Node{ID: nodeID, Data: data}
+}
+
+// Adds a directed edge to the graph
+func (g *Graph) AddEdge(source, target string) {
+	if g.Adjacency == nil {
+		g.Adjacency = make(map[string][]string)
+	}
+	g.Adjacency[source] = append(g.Adjacency[source], target)
+}
+
+// DFS to count reachable nodes
+func (g *Graph) CountReachable(nodeID string, visited map[string]bool) int {
+	if visited[nodeID] {
+		return 0
+	}
+	visited[nodeID] = true
+
+	count := 0
+	for _, neighbor := range g.Adjacency[nodeID] {
+        if !visited[neighbor] {
+            count += 1 + g.CountReachable(neighbor, visited)
+        }
+	}
+	return count
+}
+
+// Wrapper function to calculate recursive calls for all nodes
+func (g *Graph) CalculateRecursiveCalls() map[string]int {
+	result := make(map[string]int)
+	for nodeID := range g.Nodes {
+		visited := make(map[string]bool)
+		result[nodeID] = g.CountReachable(nodeID, visited)
+	}
+	return result
+}

--- a/pkg/hexctl/graph/graph_test.go
+++ b/pkg/hexctl/graph/graph_test.go
@@ -1,0 +1,97 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCountReachable_SimpleGraph(t *testing.T) {
+	graph := &Graph{}
+	graph.AddNode("A", map[string]interface{}{"key": "valueA"})
+	graph.AddNode("B", map[string]interface{}{"key": "valueB"})
+	graph.AddNode("C", map[string]interface{}{"key": "valueC"})
+	graph.AddEdge("A", "B")
+	graph.AddEdge("B", "C")
+
+	result := graph.CalculateRecursiveCalls()
+	expected := map[string]int{
+		"A": 2, // A -> B -> C
+		"B": 1, // B -> C
+		"C": 0, // No neighbors
+	}
+
+	assert.Equal(t, expected, result, "Recursive counts for Simple Graph are incorrect")
+}
+
+func TestCountReachable_DisconnectedGraph(t *testing.T) {
+	graph := &Graph{}
+	graph.AddNode("A", map[string]interface{}{"key": "valueA"})
+	graph.AddNode("B", map[string]interface{}{"key": "valueB"})
+	graph.AddNode("C", map[string]interface{}{"key": "valueC"})
+
+	// No edges
+
+	result := graph.CalculateRecursiveCalls()
+	expected := map[string]int{
+		"A": 0, // No neighbors
+		"B": 0, // No neighbors
+		"C": 0, // No neighbors
+	}
+
+	assert.Equal(t, expected, result, "Recursive counts for Disconnected Graph are incorrect")
+}
+
+func TestCountReachable_CyclicGraph(t *testing.T) {
+	graph := &Graph{}
+	graph.AddNode("A", map[string]interface{}{"key": "valueA"})
+	graph.AddNode("B", map[string]interface{}{"key": "valueB"})
+	graph.AddNode("C", map[string]interface{}{"key": "valueC"})
+	graph.AddEdge("A", "B")
+	graph.AddEdge("B", "C")
+	graph.AddEdge("C", "A") // Creates a cycle
+
+	result := graph.CalculateRecursiveCalls()
+	expected := map[string]int{
+		"A": 2, // A -> B -> C
+		"B": 2, // B -> C -> A
+		"C": 2, // C -> A -> B
+	}
+
+	assert.Equal(t, expected, result, "Recursive counts for Cyclic Graph are incorrect")
+}
+
+func TestCountReachable_MultiplePaths(t *testing.T) {
+	graph := &Graph{}
+	graph.AddNode("A", map[string]interface{}{"key": "valueA"})
+	graph.AddNode("B", map[string]interface{}{"key": "valueB"})
+	graph.AddNode("C", map[string]interface{}{"key": "valueC"})
+	graph.AddNode("D", map[string]interface{}{"key": "valueD"})
+	graph.AddEdge("A", "B")
+	graph.AddEdge("A", "C")
+	graph.AddEdge("B", "D")
+	graph.AddEdge("C", "D")
+
+	result := graph.CalculateRecursiveCalls()
+	expected := map[string]int{
+		"A": 3, // A -> B -> D, A -> C -> D
+		"B": 1, // B -> D
+		"C": 1, // C -> D
+		"D": 0, // No neighbors
+	}
+
+	assert.Equal(t, expected, result, "Recursive counts for Multiple Paths Graph are incorrect")
+}
+
+func TestCountReachable_SelfLoop(t *testing.T) {
+	graph := &Graph{}
+	graph.AddNode("A", map[string]interface{}{"key": "valueA"})
+	graph.AddEdge("A", "A") // Self-loop
+
+	result := graph.CalculateRecursiveCalls()
+	expected := map[string]int{
+		"A": 0, // Self-loops are not double-counted due to `visited` check
+	}
+
+	assert.Equal(t, expected, result, "Recursive counts for Self-Loop Graph are incorrect")
+}

--- a/pkg/hexctl/hexagon-config/branch.go
+++ b/pkg/hexctl/hexagon-config/branch.go
@@ -54,8 +54,8 @@ func NewTrunkOrBranchService(version string, tier, index uint64, isEdge bool, fa
 	}
 
 	// build fanout adapters
-	taskSpecs := []v1.TaskSpec{}
-	taskSpecs = append(taskSpecs, v1.TaskSpec{
+	taskSpecs := []*v1.TaskSpec{}
+	taskSpecs = append(taskSpecs, &v1.TaskSpec{
 		AdapterConfig: &v1.SecondaryAdapterConfig{
 			StressorConfig: &v1.StressorConfig{
 				Name:        "cpu-stressor",
@@ -71,7 +71,7 @@ func NewTrunkOrBranchService(version string, tier, index uint64, isEdge bool, fa
 	})
 	for nextIndex := range fanout {
 		taskSpecs = append(taskSpecs,
-			v1.TaskSpec{
+			&v1.TaskSpec{
 				AdapterConfig: &v1.SecondaryAdapterConfig{
 					InvocationConfig: &v1.InvocationConfig{
 						Service: fmt.Sprintf("service-%s-t%v-%v", next, tier+1, nextIndex),
@@ -95,7 +95,7 @@ func NewTrunkOrBranchService(version string, tier, index uint64, isEdge bool, fa
 		Version:        version,
 		Name:           fmt.Sprintf("service-%s-t%v-%v", this, tier, index),
 		DeploymentSpec: NewDefaultDeploymentSpec(),
-		AdapterConfigs: []v1.PrimaryAdapterSpec{
+		AdapterConfigs: []*v1.PrimaryAdapterSpec{
 			{
 				ServerConfig: &v1.ServerConfig{
 					Variant: constants.REST,

--- a/pkg/hexctl/hexagon-config/leaf.go
+++ b/pkg/hexctl/hexagon-config/leaf.go
@@ -30,14 +30,14 @@ func NewLeafService(version string, tier, index uint64) v1.ServiceUnitConfig {
 		Version:        version,
 		Name:           fmt.Sprintf("service-leaf-t%v-%v", tier, index),
 		DeploymentSpec: NewDefaultDeploymentSpec(),
-		AdapterConfigs: []v1.PrimaryAdapterSpec{
+		AdapterConfigs: []*v1.PrimaryAdapterSpec{
 			{
 				ServerConfig: &v1.ServerConfig{
 					Variant: constants.REST,
 					Action:  constants.GET,
 					Route:   "get",
 				},
-				TaskSpecs: []v1.TaskSpec{
+				TaskSpecs: []*v1.TaskSpec{
 					{
 						AdapterConfig: &v1.SecondaryAdapterConfig{
 							StressorConfig: &v1.StressorConfig{

--- a/pkg/operator/validation/fields.go
+++ b/pkg/operator/validation/fields.go
@@ -12,7 +12,7 @@ func ValidateFields(serviceUnitConfig *model.ServiceUnitConfig) ConfigValidation
 	configValidationError.Extend(validateServiceUnitConfigFields(serviceUnitConfig))
 
 	for i := range serviceUnitConfig.AdapterConfigs {
-		configValidationError.Extend(validatePrimaryAdapterConfigFields(serviceUnitConfig, &serviceUnitConfig.AdapterConfigs[i]))
+		configValidationError.Extend(validatePrimaryAdapterConfigFields(serviceUnitConfig, serviceUnitConfig.AdapterConfigs[i]))
 		for _, task := range serviceUnitConfig.AdapterConfigs[i].TaskSpecs {
 			// ensure that secondary adapter is defined
 			if task.AdapterConfig == nil {
@@ -38,7 +38,7 @@ func validateServiceUnitConfigFields(serviceUnitConfig *model.ServiceUnitConfig)
 		}
 		if repositoryConfig != nil {
 			logger.Logger.Warnf("repository adapter found, ignoring other primary adapter definitions.\n")
-			serviceUnitConfig.AdapterConfigs = []model.PrimaryAdapterSpec{
+			serviceUnitConfig.AdapterConfigs = []*model.PrimaryAdapterSpec{
 				{
 					RepositoryConfig: repositoryConfig,
 				},
@@ -65,7 +65,7 @@ func validatePrimaryAdapterConfigFields(serviceUnitConfig *model.ServiceUnitConf
 	}
 	if primaryAdapterConfig.RepositoryConfig != nil {
 		if len(primaryAdapterConfig.TaskSpecs) > 0 {
-			primaryAdapterConfig.TaskSpecs = []model.TaskSpec{} // makes sure that repository service unit config have no tasks defined
+			primaryAdapterConfig.TaskSpecs = []*model.TaskSpec{} // makes sure that repository service unit config have no tasks defined
 			logger.Logger.Warnf(
 				"Steps definition found on repository config for %s. These Steps will be ignored.\n",
 				serviceUnitConfig.Name,

--- a/pkg/operator/validation/mapping.go
+++ b/pkg/operator/validation/mapping.go
@@ -42,7 +42,7 @@ func mapSecondaryAdapters(serviceAdapterIds []string, serviceUnitConfigs []*mode
 
 // map secondary adapters to primary adapters of services
 // conditionally handle the adapters
-func mapAdapters(serviceAdapterIds []string, primaryAdapterConfig model.PrimaryAdapterSpec) []InvalidAdapterMappingError {
+func mapAdapters(serviceAdapterIds []string, primaryAdapterConfig* model.PrimaryAdapterSpec) []InvalidAdapterMappingError {
 	var mappingErrors []InvalidAdapterMappingError
 	for _, task := range primaryAdapterConfig.TaskSpecs {
 		// ensure that secondaryAdapter is defined

--- a/pkg/operator/validation/service_unit.go
+++ b/pkg/operator/validation/service_unit.go
@@ -16,7 +16,7 @@ func ValidateServiceUnitConfigFields(serviceUnitConfig *model.ServiceUnitConfig)
 	return ConfigValidationError{ServiceUnitFieldErrors: errs}
 }
 
-func ValidateStepFields(task model.TaskSpec, adapterConfig *model.PrimaryAdapterSpec, serviceName string) []InvalidStepFieldValueError {
+func ValidateStepFields(task *model.TaskSpec, adapterConfig *model.PrimaryAdapterSpec, serviceName string) []InvalidStepFieldValueError {
 	var taskFieldErrors []InvalidStepFieldValueError
 	if task.AdapterConfig == nil {
 		taskFieldErrors = append(taskFieldErrors, NewInvalidStepFieldValueError(adapterConfig.GetId(serviceName)))

--- a/test/mock/primary.go
+++ b/test/mock/primary.go
@@ -32,7 +32,7 @@ func NewPrimaryHandler(numTask int) domain.PrimaryAdapterHandler {
 		tasks = append(tasks,
 			resiliency.NewTaskHandler(
 				domain.TelemetryContext{PrimaryLabels: domain.PrimaryLabels{ServiceName: "RegularCallHandler"}},
-				model.TaskSpec{},
+				&model.TaskSpec{},
 				NewSecondaryAdapter("RegularSecondaryAdapter1", time.Second, 0),
 			))
 	}


### PR DESCRIPTION
`hexctl adapto` adds adaptive timeout configuration to existing configs.
The basic configurations for the adaptive timeout should be given in cluster config using `adaptiveTimeout`.
The command assigns latencySLO based on endpoints that the adapter accesses recursively.